### PR TITLE
chore(git): add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+npm-debug.log


### PR DESCRIPTION
We are not interested in checking in the `node_modules` folder and an
eventual `npm` debug log file.

This patch adds them to the `.gitignore` file.