### PR TITLE
WIP: feat: basic browser extension support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 2,
+  "name": "Over 9000 - The Autopilot for Human Testing",
+  "version": "0.3",
+  "description": "Make manual UI testing fun again.",
+  "content_scripts": [
+    {
+      "matches": ["http://localhost:*/*"],
+      "css": ["src/o9k.css"],
+      "js": ["src/o9k.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "browser_action": {
+    "default_title": "Start Testing..."
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,8 @@
   "name": "Over 9000 - The Autopilot for Human Testing",
   "version": "0.3",
   "description": "Make manual UI testing fun again.",
+  
+  "devtools_page": "src/devtools.html",
   "content_scripts": [
     {
       "matches": ["http://localhost:*/*"],
@@ -10,8 +12,5 @@
       "js": ["src/o9k.js"],
       "run_at": "document_start"
     }
-  ],
-  "browser_action": {
-    "default_title": "Start Testing..."
-  }
+  ]
 }

--- a/src/devtools.html
+++ b/src/devtools.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="devtools.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -1,0 +1,1 @@
+chrome.devtools.panels.create('Over 9000', null, 'src/panel.html');

--- a/src/o9k_ui.js
+++ b/src/o9k_ui.js
@@ -1,0 +1,615 @@
+class ElementLocator {
+  constructor(element) {
+    this._element = element;
+  }
+
+  byXpath() {
+    return {
+      type: 'xpath',
+      value: createXPathFromElement(this._element)
+    };
+  }
+
+  byText() {
+    const text = this._element.textContent;
+
+    return {
+      type: 'xpath',
+      value: `//${this._element.localName}[contains(., "${text}")]`
+    };
+  }
+
+  byId() {
+    return {
+      type: 'id',
+      value: this._element.id
+    };
+  }
+
+  byName() {
+    return {
+      type: 'name',
+      value: this._element.name
+    };
+  }
+
+  byPlaceholder() {
+    return {
+      type: 'css selector',
+      value: `input[placeholder="${this._element.placeholder}"]`
+    };
+  }
+
+  byLink() {
+    const title = this._element.textContent;
+    if (title) {
+      return this.byText();
+    }
+
+    const href = this._element.href;
+    return {
+      type: 'css selector',
+      value: `a[href="${href}"]`
+    };
+  }
+
+  byImage() {
+    const alt = this._element.alt;
+    if (alt) {
+      return {
+        type: 'css selector',
+        value: `img[alt="${alt}"]`
+      };
+    }
+
+    // Use `attributes` to get src as in HTML, not normalized by DOM
+    const src = this._element.attributes['src'].value;
+    return {
+      type: 'css selector',
+      value: `img[src="${src}"]`
+    };
+  }
+
+  byLabelText() {
+      const text = this._element.textContent;
+
+      return {
+        type: 'xpath',
+        value: `//input[@id=(//label[contains(., "${labelText}")]/@for)]`
+      };
+  }
+}
+
+class BodyTextAssertion {
+  toEvent() {
+    const bodyText = document.documentElement.innerText;
+    const o9kUiText = window.o9kUi.innerText;
+    const appBodyText = bodyText.substring(0, bodyText.lastIndexOf(o9kUiText));
+
+    return {
+      type: 'assertBodyText',
+      text: appBodyText
+    }
+  }
+}
+
+class TextAssertion {
+  constructor(element) {
+    this._element = element;
+  }
+
+  toEvent() {
+    return {
+      type: 'assertText',
+      locator: selectorsForClickElement(this._element),
+      text: this._element.innerText
+    }
+  }
+}
+
+class TextPresentAssertion {
+  constructor(element) {
+    this._element = element;
+  }
+
+  toEvent() {
+    return {
+      type: 'assertTextPresent',
+      text: this._element.innerText
+    }
+  }
+}
+
+class ElementValueAssertion {
+  constructor(element) {
+    this._element = element;
+  }
+
+  toEvent() {
+    return {
+      type: 'assertElementValue',
+      locator: selectorForInput(this._element),
+      value: this._element.value
+    }
+  }
+}
+
+class ElementAssertion {
+  constructor(element) {
+    this._element = element;
+  }
+
+  toEvent() {
+    return {
+      type: 'assertElementPresent',
+      locator: selectorsForClickElement(this._element)
+    }
+  }
+}
+
+class LoadEvent {
+  toEvent() {
+    return {
+      type: 'get',
+      url: window.location.pathname
+    }
+  }
+}
+
+class ClickEvent {
+  constructor(element) {
+    this._element = element;
+  }
+
+  toEvent() {
+    return {
+      type: 'clickElement',
+      locator: selectorsForClickElement(this._element)
+    }
+  }
+}
+
+class SetTextEvent {
+  constructor(element) {
+    this._element = element;
+  }
+
+  toEvent() {
+    return {
+      type: 'setElementText',
+      locator: selectorForInput(this._element),
+      text: this._element.value
+    }
+  }
+}
+
+
+function createXPathFromElement(elm) {
+    var allNodes = document.getElementsByTagName('*');
+    for (var segs = []; elm && elm.nodeType == 1; elm = elm.parentNode)
+    {
+        if (elm.hasAttribute('id')) {
+                var uniqueIdCount = 0;
+                for (var n=0;n < allNodes.length;n++) {
+                    if (allNodes[n].hasAttribute('id') && allNodes[n].id == elm.id) uniqueIdCount++;
+                    if (uniqueIdCount > 1) break;
+                };
+                if ( uniqueIdCount == 1) {
+                    segs.unshift('id("' + elm.getAttribute('id') + '")');
+                    return segs.join('/');
+                } else {
+                    segs.unshift(elm.localName.toLowerCase() + '[@id="' + elm.getAttribute('id') + '"]');
+                }
+        } else if (elm.hasAttribute('class')) {
+            segs.unshift(elm.localName.toLowerCase() + '[@class="' + elm.getAttribute('class') + '"]');
+        } else {
+            let i;
+            for (i = 1, sib = elm.previousSibling; sib; sib = sib.previousSibling)
+            {
+              if (sib.localName == elm.localName)  i++;
+            };
+              segs.unshift(elm.localName.toLowerCase() + '[' + i + ']');
+        };
+    };
+    return segs.length ? '/' + segs.join('/') : null;
+};
+
+window.events = [];
+
+function selectorForInput(e) {
+  const locator = new ElementLocator(e);
+
+  if (e.id) {
+    let label = document.querySelector(`label[for="${e.id}"]`);
+    if (label) {
+      return locator.byLabelText();
+    } else {
+      return locator.byName();
+    }
+  }
+
+  if (e.placeholder) {
+    return locator.byPlaceholder();
+  }
+
+  return locator.byXpath();
+}
+
+function selectorsForClickElement(e) {
+  const locator = new ElementLocator(e);
+
+  if (e.localName === 'input') {
+    const buttonTypes = [
+      'submit', 'reset', 'image', 'button'
+    ];
+
+    if (buttonTypes.includes(e.type)) {
+      return locator.byText();
+    }
+
+    return selectorForInput(e);
+  }
+
+  if (e.localName === 'button') {
+    return locator.byText();
+  }
+
+  if (e.localName === 'img') {
+    return locator.byImage();
+  }
+
+  if (e.localName === 'a') {
+    return locator.byLink();
+  }
+
+  return locator.byXpath();
+}
+
+function isTextElement(element) {
+  return element.localName === 'input';
+}
+
+function clearEvents() {
+  window.events = [];
+  storeEvents();
+}
+
+function storeEvents() {
+  window.localStorage[`o9k.steps.${window.location.href}`] = JSON.stringify(window.events);
+}
+
+function loadEvents() {
+  const events = window.localStorage[`o9k.steps.${window.location.href}`];
+  if (!events) return;
+
+  window.events = JSON.parse(events);
+
+  if (window.events.length > 0) {
+    updateEvents();
+  } else {
+    const loadEvent = new LoadEvent();
+    addEvent(loadEvent);
+  }
+}
+
+function addEvent(event) {
+  if (!event) return;
+
+  window.events.push(event.toEvent());
+  updateEvents();
+  storeEvents();
+}
+
+function removeEvent(index) {
+  if (!index) return;
+
+  window.events.splice(index, 1);
+
+  updateEvents();
+  storeEvents();
+}
+
+function exportSeleniumBuilder() {
+  let result = {
+    type: "script",
+    seleniumVersion: "2",
+    formatVersion: 2,
+    steps: window.events,
+    data: {
+      configs: {},
+      source: "none"
+    },
+    inputs: [],
+    timeoutSeconds: 60
+  }
+
+  return JSON.stringify(result, null, '  ');
+}
+
+function prepareExport() {
+  let link = document.querySelector('#ui9k-export-builder');
+  let content = exportSeleniumBuilder();
+  link.href = "data:application/octet-stream," + encodeURIComponent(content);
+}
+
+class StepRecorder {
+  constructor() {
+    this._mode = 'step';
+  }
+
+  get isActive() {
+    return this._active;
+  }
+
+  start() {
+    this._active = true;
+    this.setupHandlers();
+  }
+
+  stop() {
+    this._active = false;
+    this.teardownHandlers();
+  }
+
+  toggle() {
+    this._active ? this.stop() : this.start();
+  }
+
+  eventFilter(e) {
+    const ui9k = window.o9kUi;
+    return e.path.includes(ui9k);
+  }
+}
+
+class EventRecorder extends StepRecorder {
+  handleEvent(e) {
+    if (this.eventFilter(e)) return;
+
+    if (e.type === 'DOMContentLoaded') {
+      const event = new LoadEvent();
+      addEvent(event);
+    }
+
+    if (e.type === 'click') {
+      const event = new ClickEvent(e.target);
+      addEvent(event);
+    }
+
+    if (e.type === 'blur') {
+      if (!isTextElement(e.target)) {
+        // No text setting if bluring on non-input
+        return;
+      }
+
+      const event = new SetTextEvent(e.target);
+      addEvent(event);
+    }
+  }
+
+  setupHandlers() {
+    document.addEventListener('DOMContentLoaded', this, true);
+    document.addEventListener('blur', this, true);
+    document.addEventListener('focusin', this, true);
+    document.addEventListener('click', this, true);
+  }
+
+  teardownHandlers() {
+    document.removeEventListener('DOMContentLoaded', this, true);
+    document.removeEventListener('blur', this, true);
+    document.removeEventListener('focusin', this, true);
+    document.removeEventListener('click', this, true);
+  }
+}
+
+class AssertionRecorder extends StepRecorder {
+  handleEvent(e) {
+    if (this.eventFilter(e)) return;
+
+    e.stopPropagation();
+    e.preventDefault();
+
+    switch(e.type) {
+      case 'mouseover':
+        this.focusElement(e.target);
+      break;
+
+      case 'click':
+        this.pick();
+      break;
+    }
+  }
+
+  stop() {
+    this._active = false;
+    this.teardownHandlers();
+    this.blurElement();
+  }
+
+  setupHandlers() {
+    document.addEventListener('mouseover', this, true);
+    document.addEventListener('click', this, true);
+  }
+
+  teardownHandlers() {
+    document.removeEventListener('mouseover', this, true);
+    document.removeEventListener('click', this, true);
+  }
+
+  blurElement() {
+    if (this._focusedElement) {
+      this._focusedElement.style = this._styleBackup;
+    }
+  }
+
+  focusElement(element) {
+    this.blurElement();
+
+    this._styleBackup = element.style;
+    element.style['box-shadow'] = 'inset 0px 0px 0px 1px #000';
+
+    this._focusedElement = element;
+  }
+
+  pick() {
+    if (isTextElement(this._focusedElement)) {
+      const assertion = new ElementValueAssertion(this._focusedElement);
+      addEvent(assertion);
+    } else if (this._focusedElement.innerText) {
+      const assertion = new TextAssertion(this._focusedElement);
+      if (assertion.toEvent().locator.value.startsWith('/html')) {
+        const textAssertion = new TextPresentAssertion(this._focusedElement);
+        addEvent(textAssertion);
+      } else {
+        addEvent(assertion);
+      }
+    } else {
+      const assertion = new ElementAssertion(this._focusedElement);
+      addEvent(assertion);
+    }
+  }
+}
+
+function resetEvents() {
+  window.assertionRecorder.stop();
+  window.eventRecorder.start();
+
+  clearEvents();
+
+  loadEvents();
+}
+
+function renderEvent(event) {
+  switch (event.type) {
+    case 'clickElement':
+      return `
+<li>
+  ${event.type}:
+  ${event.locator.type}
+  ${event.locator.value}
+</li>
+  `;
+
+    case 'get':
+      return `
+<li>
+  ${event.type}:
+  ${event.url}
+</li>
+  `;
+
+    case 'setElementText':
+      return `
+<li>
+  ${event.type}:
+  ${event.locator.type}
+  ${event.locator.value}
+  ${event.text}
+</li>
+  `;
+
+    case 'assertElementValue':
+      return `
+<li>
+${event.type}:
+${event.locator.type}
+${event.locator.value}
+${event.value}
+</li>
+  `;
+
+    case 'assertElementPresent':
+      return `
+<li>
+${event.type}:
+${event.locator.type}
+${event.locator.value}
+</li>
+  `;
+
+    case 'assertText':
+      return `
+<li>
+${event.type}:
+${event.locator.type}
+${event.locator.value}
+${event.text}
+</li>
+  `;
+
+    case 'assertTextPresent':
+      return `
+<li>
+${event.type}:
+${event.text}
+</li>
+  `;
+  }
+}
+
+function renderDeletableEvent(event, index) {
+  return `
+<div style="display: flex; flex-direction: row">
+  <div style="flex: 0 0 auto">
+    <button onclick="removeEvent(${index})">&times;</button>
+  </div>
+  <div style="flex: 1 1 auto">
+    ${renderEvent(event)}
+  </div>
+</div>
+  `;
+}
+
+function renderEvents(events) {
+  return events.map((event, index) => renderDeletableEvent(event, index));
+}
+
+function updateEvents() {
+  document.querySelector('#ui9k-events').innerHTML = renderEvents(window.events);
+}
+
+function addUi9k() {
+  console.log('Initialize o9k UI...');
+  let ui = `
+<div id="ui9k">
+  <div style="background: #f8f8f8; padding: 10px 0">
+    <div style="padding: 0 20px;">Over 9000</div>
+  </div>
+  <div>
+    <a onclick="resetEvents()">reset</a>
+  </div>
+  <div>
+    <a id="ui9k-export-builder" onclick="prepareExport()">Export Selenium Builder</a>
+  </div>
+  <div>
+    <a onclick="assertionRecorder.toggle(); eventRecorder.toggle()">Add Assertion</a>
+  </div>
+  <ol id="ui9k-events">
+    ${renderEvents(window.events)}
+  </ol>
+</div>
+`;
+
+  document.body.insertAdjacentHTML('beforeend', ui);
+  console.log('Initialized o9k UI');
+  document.body.style.marginLeft = '20%';
+
+  window.o9kUi = document.querySelector('#ui9k');
+  window.assertionRecorder = new AssertionRecorder();
+  window.assertionRecorder.stop();
+  window.eventRecorder = new EventRecorder();
+  window.eventRecorder.start();
+
+  loadEvents();
+}
+document.addEventListener('DOMContentLoaded', addUi9k, true);
+
+function patchIonic() {
+  const ngApp = document.querySelector('[ng-app]');
+  if (!ngApp) {
+    return;
+  }
+
+  ngApp.dataset['tapDisabled'] = "true";
+}
+document.addEventListener('DOMContentLoaded', patchIonic, true);
+

--- a/src/panel.html
+++ b/src/panel.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script src="panel.js"></script>
+  </head>
+  <body>
+    Over 9000
+  </body>
+</html>

--- a/src/panel.html
+++ b/src/panel.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="panel.js"></script>
+    <script src="o9k_ui.js"></script>
   </head>
   <body>
     Over 9000

--- a/src/panel.js
+++ b/src/panel.js
@@ -1,6 +1,0 @@
-function l() {
-  console.info('testing');
-  document.body.insertAdjacentHTML('beforeend', 'quack');
-};
-
-document.addEventListener('DOMContentLoaded', l, true);

--- a/src/panel.js
+++ b/src/panel.js
@@ -1,0 +1,6 @@
+function l() {
+  console.info('testing');
+  document.body.insertAdjacentHTML('beforeend', 'quack');
+};
+
+document.addEventListener('DOMContentLoaded', l, true);


### PR DESCRIPTION
o9k comes with a UI and needs control over the running application.
These tasks are both hard to implement as classic web applications.

This patch introduces a basic manifest to support using o9k as a browser
extension. It currently does not come with an icon and simply attaches
itself to all applications running on `localhost`. This will be improved
in follow up commits.

Further down the road we might switch from a basic browser extension to
a debugger extension. This will be semantically better and gives even
more access to some APIs we might be interested.

Related to #7